### PR TITLE
Set IOC service name

### DIFF
--- a/services/bl01t-di-cam-01/compose.yml
+++ b/services/bl01t-di-cam-01/compose.yml
@@ -7,6 +7,7 @@ services:
       file: ../../include/ioc.yml
 
     image: ghcr.io/epics-containers/ioc-adsimdetector-runtime:2024.6.1
+    container_name: ${IOC_NAME}
 
     labels:
       # this should be incremented when changes are made to this file

--- a/services/bl01t-ea-test-01/compose.yml
+++ b/services/bl01t-ea-test-01/compose.yml
@@ -7,6 +7,7 @@ services:
       file: ../../include/ioc.yml
 
     image: ghcr.io/epics-containers/ioc-adsimdetector-runtime:2024.6.1
+    container_name: ${IOC_NAME}
 
     labels:
       # this should be incremented when changes are made to this file


### PR DESCRIPTION
A fix for our IOCs which get the name: "bl01t-bl01t-di-cam-01-1"